### PR TITLE
Handle undefined base64 error on pdf select

### DIFF
--- a/services/llm.ts
+++ b/services/llm.ts
@@ -1,8 +1,8 @@
-import 'react-native-get-random-values';
 import * as DocumentPicker from 'expo-document-picker';
 import * as FileSystem from 'expo-file-system';
-import { v4 as uuidv4 } from 'uuid';
 import OpenAI from 'openai';
+import 'react-native-get-random-values';
+import { v4 as uuidv4 } from 'uuid';
 import type { MealPlanDetails, MealSuggestion, MealType } from './storage';
 
 let openaiClient: OpenAI | null = null;
@@ -35,7 +35,8 @@ export async function parseMealPlanPdf(apiKey: string, pdfUri: string, pdfName: 
   if (!openaiClient) configureOpenAI(apiKey);
   if (!openaiClient) throw new Error('OpenAI client not configured');
 
-  const fileBase64 = await FileSystem.readAsStringAsync(pdfUri, { encoding: FileSystem.EncodingType.Base64 });
+  const base64Encoding: any = (FileSystem as any).EncodingType?.Base64 ?? 'base64';
+  const fileBase64 = await FileSystem.readAsStringAsync(pdfUri, { encoding: base64Encoding });
 
   const systemPrompt = `You are a nutrition assistant. Extract structured details from the provided meal plan PDF. Return JSON with keys: title (string), caloriesPerDay (number, optional), restrictions (string[]), dislikedIngredients (string[], optional), notes (string, optional). If values not found, omit.`;
 


### PR DESCRIPTION
Fix 'Cannot read property 'Base64' of undefined' error by using a string literal fallback for base64 encoding.

---
<a href="https://cursor.com/background-agent?bcId=bc-8b1e1e66-fed2-45f5-b52c-d9468558dbc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8b1e1e66-fed2-45f5-b52c-d9468558dbc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

