### PR TITLE
Investigate pdf selection error

### DIFF
--- a/services/llm.ts
+++ b/services/llm.ts
@@ -1,5 +1,5 @@
 import * as DocumentPicker from 'expo-document-picker';
-import * as FileSystem from 'expo-file-system/legacy';
+import { File } from 'expo-file-system';
 import OpenAI from 'openai';
 import 'react-native-get-random-values';
 import { v4 as uuidv4 } from 'uuid';
@@ -35,8 +35,8 @@ export async function parseMealPlanPdf(apiKey: string, pdfUri: string, pdfName: 
   if (!openaiClient) configureOpenAI(apiKey);
   if (!openaiClient) throw new Error('OpenAI client not configured');
 
-  const base64Encoding: any = (FileSystem as any).EncodingType?.Base64 ?? 'base64';
-  const fileBase64 = await FileSystem.readAsStringAsync(pdfUri, { encoding: base64Encoding });
+  const file = await File.fromUriAsync(pdfUri);
+  const fileBase64 = await file.readAsStringAsync({ encoding: 'base64' });
 
   const systemPrompt = `You are a nutrition assistant. Extract structured details from the provided meal plan PDF. Return JSON with keys: title (string), caloriesPerDay (number, optional), restrictions (string[]), dislikedIngredients (string[], optional), notes (string, optional). If values not found, omit.`;
 

--- a/services/llm.ts
+++ b/services/llm.ts
@@ -1,5 +1,5 @@
 import * as DocumentPicker from 'expo-document-picker';
-import * as FileSystem from 'expo-file-system';
+import * as FileSystem from 'expo-file-system/legacy';
 import OpenAI from 'openai';
 import 'react-native-get-random-values';
 import { v4 as uuidv4 } from 'uuid';


### PR DESCRIPTION
Update `expo-file-system` import to fix an error when selecting a PDF.

The previous `expo-file-system` import was using a deprecated API, causing an error when attempting to read a PDF file. Switching to `expo-file-system/legacy` resolves this issue by using the older, still supported API.

---
<a href="https://cursor.com/background-agent?bcId=bc-e3ceed3c-2d8e-4066-a618-c8c2c34e30dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e3ceed3c-2d8e-4066-a618-c8c2c34e30dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

